### PR TITLE
修复账号密码注册时无法上传头像的问题

### DIFF
--- a/src/main/java/com/jinlink/modules/file/service/impl/SysFileServiceImpl.java
+++ b/src/main/java/com/jinlink/modules/file/service/impl/SysFileServiceImpl.java
@@ -74,6 +74,14 @@ public class SysFileServiceImpl implements SysFileService {
                     .fileUrl(fileUrl)
                     .status("1")
                     .build();
+        }if (ObjectUtil.isNull(loginUser)){
+            monLogsFile = MonLogsFile.builder()
+                    .userId(-1)
+                    .userName("unregistered")
+                    .fileSize(FileUtils.getFileSizeInMB(file))
+                    .fileUrl(fileUrl)
+                    .status("0")
+                    .build();
         }else{
             monLogsFile = MonLogsFile.builder()
                     .userId(loginUser.getId())


### PR DESCRIPTION
使用账号密码注册时，需要上传头像，上传头像调用此API `https://www.bluearchive.top/api/file/upload`。
上传完成后，应该是往数据库保存一条日志，日志存在用户ID和用户名字段。
代码中没有判断是否为未注册用户，而数据库中日志表`mon_logs_file`的`user_id`应该为非NULL，导致接口无法正常返回。
我新增了判断LoginUser为空时，将userId置为-1，userName设为unregistered，如有更好的方法也可。

```java
if (ObjectUtil.isNull(loginUser)){
        monLogsFile = MonLogsFile.builder()
                .userId(-1)
                .userName("unregistered")
                .fileSize(FileUtils.getFileSizeInMB(file))
                .fileUrl(fileUrl)
                .status("0")
                .build();
```

接口返回日志如下：
```json
{
    "code": 403,
    "msg": "\r\n### Error updating database.  Cause: java.sql.SQLException: Field 'user_name' doesn't have a default value\r\n### The error may exist in com/jinlink/modules/monitor/mapper/MonLogsFileMapper.java (best guess)\r\n### The error may involve com.jinlink.modules.monitor.mapper.MonLogsFileMapper.insert\r\n### The error occurred while executing an update\r\n### SQL: INSERT INTO `mon_logs_file`(`user_id`, `file_url`, `file_size`, `status`, `create_user_id`, `create_time`, `update_user_id`, `update_time`, `is_deleted`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)\r\n### Cause: java.sql.SQLException: Field 'user_name' doesn't have a default value\n; Field 'user_name' doesn't have a default value",
    "data": null,
    "timestamp": 1739080678229
}
```